### PR TITLE
[NOTION-535] relax version control of google packages to handle newer releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="googleauthentication",
-    version="0.0.18",
+    version="0.0.19",
     author="Dacker",
     author_email="hello@dacker.co",
     description="A meta package to be connected to Google services",
@@ -20,12 +20,12 @@ setuptools.setup(
     ],
     python_requires='>=3',
     install_requires=[
-        "google-api-python-client==1.7.11",
+        "google-api-python-client>=1.7.11",
         "google-auth>=1.23.0",
-        "google-auth-httplib2==0.0.3",
+        "google-auth-httplib2>=0.0.3",
         "google-auth-oauthlib>=0.4.0",
         "cryptography>=2.7",
         "dbstream>=0.0.12",
-        "google-cloud-secret-manager==2.7.2"
+        "google-cloud-secret-manager>=2.7.2"
     ]
 )


### PR DESCRIPTION
"google-cloud-secret-manager==2.7.2"

In the package setup entailed that 
"dbstream==0.1.28
bigquery==0.0.45
google-cloud-storage>=2.9.0
google-cloud-secret-manager>=2.16.1
pyyaml>=6.0" 

failed in the retaillint connector requirements